### PR TITLE
[SMC-4] Tweak Nginx config to address ZAP issues

### DIFF
--- a/.github/workflows/build_push_terra.yml
+++ b/.github/workflows/build_push_terra.yml
@@ -10,6 +10,7 @@ on:
       - "*.json"
       - "*.ts"
       - "Dockerfile"
+      - "nginx.conf"
       - "public/**"
       - "src/**"
       - ".github/workflows/build_push_terra.yml"
@@ -20,6 +21,7 @@ on:
       - "*.json"
       - "*.ts"
       - "Dockerfile"
+      - "nginx.conf"
       - "public/**"
       - "src/**"
       - ".github/workflows/build_push_terra.yml"
@@ -148,7 +150,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
-  
+
   set-version-in-terra-dev:
     # Put new version in Broad dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ ARG APP_VERSION=latest
 ARG BUILD_VERSION=latest
 
 RUN echo "{\"appVersion\": \"$APP_VERSION\", \"buildVersion\": \"$BUILD_VERSION\"}" > dist/version
+RUN mv nginx.conf nginx.default.conf && touch default.conf
 
 FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:distroless
 
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/*.conf /etc/nginx/conf.d/
 COPY --from=build /app/dist /usr/share/nginx/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,8 @@ ARG APP_VERSION=latest
 ARG BUILD_VERSION=latest
 
 RUN echo "{\"appVersion\": \"$APP_VERSION\", \"buildVersion\": \"$BUILD_VERSION\"}" > dist/version
-RUN mv nginx.conf nginx.default.conf && touch default.conf
 
 FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:distroless
 
-COPY --from=build /app/*.conf /etc/nginx/conf.d/
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html/

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ server {
     add_header Cache-Control $cache_control always;
 
     # Security
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://sfkit.dsde-dev.broadinstitute.org https://sfkit.dsde-prod.broadinstitute.org; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://sfkit.dsde-dev.broadinstitute.org https://sfkit.dsde-prod.broadinstitute.org https://firecloud-orchestration.dsde-dev.broadinstitute.org https://firecloud-orchestration.dsde-prod.broadinstitute.org; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,7 +5,6 @@ map $request_uri $cache_control {
 
 server {
     listen       8080;
-    server_name  localhost;
     server_tokens off;
 
     # Caching
@@ -22,7 +21,6 @@ server {
 
     location / {
         root   /usr/share/nginx/html;
-        index  index.html index.htm;
         try_files $uri $uri/ /index.html;
 
         location = /version {

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,23 +13,24 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # Caching headers
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
 
-        add_header Cache-Control "max-age=31536000, immutable" always;
+        location /assets {
+            add_header Cache-Control "max-age=31536000, immutable" always;
+        }
+
+        location = /dna.webp {
+            add_header Cache-Control "max-age=86400" always;
+        }
     }
 
-    location = / {
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-    }
-
-    location = /dna.webp {
-        add_header Cache-Control "max-age=86400" always;
-    }
-
-    location = /latest/meta-data/ {
+    location /latest/meta-data {
         return 404;
     }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 map $request_uri $cache_control {
-    default     "no-cache, no-store, must-revalidate";
-    ~^/assets   "max-age=31536000, immutable";
+    default "no-cache, no-store, must-revalidate";
+    ~^/(assets|latest/meta-data|status) "max-age=31536000, immutable";
 }
 
 server {
@@ -30,6 +30,7 @@ server {
         }
     }
 
+    # needed to satisfy Zap
     location /latest/meta-data {
         return 404;
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,8 +11,7 @@ server {
     add_header Cache-Control $cache_control always;
 
     # Security
-    add_header Cross-Origin-Embedder-Policy "credentialless" always;
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://*.googleapis.com; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,33 +1,29 @@
+map $request_uri $cache_control {
+    default     "no-cache, no-store, must-revalidate";
+    ~^/assets   "max-age=31536000, immutable";
+}
+
 server {
     listen       8080;
     server_name  localhost;
     server_tokens off;
 
-    # Security headers
+    # Security
     add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Server "Apache" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # Caching headers
-    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    # Caching
+    add_header Cache-Control $cache_control always;
 
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
-
-        location /assets {
-            add_header Cache-Control "max-age=31536000, immutable" always;
-        }
-
-        location = /dna.webp {
-            add_header Cache-Control "max-age=86400" always;
-        }
 
         location = /version {
             access_log off;
@@ -39,12 +35,7 @@ server {
     }
 
     location = /status {
-        return 200;
         access_log off;
-    }
-
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
+        return 200;
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ server {
     add_header Cache-Control $cache_control always;
 
     # Security
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://*.googleapis.com; font-src 'self'; frame-src https://www.youtube-nocookie.com'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://*.googleapis.com; font-src 'self'; frame-src https://www.youtube-nocookie.com; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ server {
     add_header Cache-Control $cache_control always;
 
     # Security
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://sfkit.dsde-dev.broadinstitute.org https://sfkit.dsde-prod.broadinstitute.org; font-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://sfkit.dsde-dev.broadinstitute.org https://sfkit.dsde-prod.broadinstitute.org; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,7 +12,7 @@ server {
 
     # Security
     add_header Cross-Origin-Embedder-Policy "credentialless" always;
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://sfkit.dsde-dev.broadinstitute.org https://sfkit.dsde-prod.broadinstitute.org https://firecloud-orchestration.dsde-dev.broadinstitute.org https://firecloud-orchestration.dsde-prod.broadinstitute.org; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,7 +20,7 @@ server {
 
     # Security
     add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' $connect_src; font-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
-    add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
+    add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,14 @@ map $request_uri $cache_control {
     ~^/(assets|latest/meta-data) "max-age=31536000, immutable";
 }
 
+map $host $connect_src {
+    default "";
+    ~^dev.sfkit.org "https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app";
+    ~^sfkit.org "https://sfkit-website-bhj5a4wkqa-uc.a.run.app";
+    ~^sfkitui.dsde-dev.broadinstitute.org "https://sfkit.dsde-dev.broadinstitute.org";
+    ~^sfkit.terra.bio "https://sfkit.dsde-prod.broadinstitute.org";
+}
+
 server {
     listen       8080;
     server_tokens off;
@@ -11,7 +19,7 @@ server {
     add_header Cache-Control $cache_control always;
 
     # Security
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org; font-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' $connect_src; font-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,16 +13,20 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    location = / {
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-    }
-
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
 
         add_header Cache-Control "max-age=31536000, immutable" always;
+    }
+
+    location = / {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    }
+
+    location = /dna.webp {
+        add_header Cache-Control "max-age=86400" always;
     }
 
     location = /latest/meta-data/ {

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ server {
     add_header Cache-Control $cache_control always;
 
     # Security
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://*.googleapis.com; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://*.googleapis.com https://www.youtube-nocookie.com; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,9 +11,15 @@ map $http_host $connect_src {
     ~^sfkit.terra.bio "https://sfkit.dsde-prod.broadinstitute.org";
 }
 
+log_format  my_host  'host: $host; hostname: $hostname; http_host: $http_host; $remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
 server {
     listen       8080;
     server_tokens off;
+
+    access_log  /var/log/nginx/access.log  my_host;
 
     # Caching
     add_header Cache-Control $cache_control always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,7 +13,6 @@ map $http_host $connect_src {
 
 server {
     listen       8080;
-    server_name  localhost;
     server_tokens off;
 
     # Caching

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,7 +14,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
 
     location = / {
-        add_header Cache-Control "no-store" always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
     }
 
     location / {

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,13 +4,14 @@ server {
     server_tokens off;
 
     # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "script-src 'self'; object-src 'none'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Server "Apache" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
 
     # Cache control headers
     add_header Cache-Control "no-store" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,7 +4,7 @@ server {
     server_tokens off;
 
     # Security headers
-    add_header Content-Security-Policy "script-src 'self'; object-src 'none'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Server "Apache" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,7 +3,7 @@ map $request_uri $cache_control {
     ~^/(assets|latest/meta-data) "max-age=31536000, immutable";
 }
 
-map $host $connect_src {
+map $http_host $connect_src {
     default "";
     ~^dev.sfkit.org "https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app";
     ~^sfkit.org "https://sfkit-website-bhj5a4wkqa-uc.a.run.app";

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 map $request_uri $cache_control {
     default "no-cache, no-store, must-revalidate";
-    ~^/(assets|latest/meta-data|status) "max-age=31536000, immutable";
+    ~^/(assets|latest/meta-data) "max-age=31536000, immutable";
 }
 
 server {

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,7 @@ server {
     add_header Cache-Control $cache_control always;
 
     # Security
+    add_header Cross-Origin-Embedder-Policy "credentialless" always;
     add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://sfkit.dsde-dev.broadinstitute.org https://sfkit.dsde-prod.broadinstitute.org https://firecloud-orchestration.dsde-dev.broadinstitute.org https://firecloud-orchestration.dsde-prod.broadinstitute.org; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,29 +3,15 @@ map $request_uri $cache_control {
     ~^/(assets|latest/meta-data) "max-age=31536000, immutable";
 }
 
-map $http_host $connect_src {
-    default "";
-    ~^dev.sfkit.org "https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app";
-    ~^sfkit.org "https://sfkit-website-bhj5a4wkqa-uc.a.run.app";
-    ~^sfkitui.dsde-dev.broadinstitute.org "https://sfkit.dsde-dev.broadinstitute.org";
-    ~^sfkit.terra.bio "https://sfkit.dsde-prod.broadinstitute.org";
-}
-
-log_format  my_host  'host: $host; hostname: $hostname; http_host: $http_host; $remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
-
 server {
     listen       8080;
     server_tokens off;
-
-    access_log  /var/log/nginx/access.log  my_host;
 
     # Caching
     add_header Cache-Control $cache_control always;
 
     # Security
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' $connect_src; font-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://sfkit.dsde-dev.broadinstitute.org https://sfkit.dsde-prod.broadinstitute.org; font-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,7 +25,11 @@ server {
         add_header Cache-Control "max-age=31536000, immutable" always;
     }
 
-    location /status {
+    location = /latest/meta-data/ {
+        return 404;
+    }
+
+    location = /status {
         return 200;
         access_log off;
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ server {
     add_header Cache-Control $cache_control always;
 
     # Security
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://*.googleapis.com; font-src 'self'; frame-src https://www.youtube-nocookie.com' img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://*.googleapis.com; font-src 'self'; frame-src https://www.youtube-nocookie.com'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ server {
     add_header Cache-Control $cache_control always;
 
     # Security
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org; font-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -28,6 +28,10 @@ server {
         location = /dna.webp {
             add_header Cache-Control "max-age=86400" always;
         }
+
+        location = /version {
+            access_log off;
+        }
     }
 
     location /latest/meta-data {

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ server {
     add_header Cache-Control $cache_control always;
 
     # Security
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://*.googleapis.com https://www.youtube-nocookie.com; font-src 'self'; img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app https://sfkit-website-bhj5a4wkqa-uc.a.run.app https://*.dsde-dev.broadinstitute.org https://*.dsde-prod.broadinstitute.org https://*.googleapis.com; font-src 'self'; frame-src https://www.youtube-nocookie.com' img-src 'self' blob:; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,6 +13,7 @@ map $http_host $connect_src {
 
 server {
     listen       8080;
+    server_name  localhost;
     server_tokens off;
 
     # Caching

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,6 +8,9 @@ server {
     server_name  localhost;
     server_tokens off;
 
+    # Caching
+    add_header Cache-Control $cache_control always;
+
     # Security
     add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'; require-trusted-types-for 'script';" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
@@ -16,9 +19,6 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
-
-    # Caching
-    add_header Cache-Control $cache_control always;
 
     location / {
         root   /usr/share/nginx/html;

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,14 +13,16 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # Cache control headers
-    add_header Cache-Control "no-store" always;
-    add_header Pragma "no-cache" always;
+    location = / {
+        add_header Cache-Control "no-store" always;
+    }
 
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
+
+        add_header Cache-Control "max-age=31536000, immutable" always;
     }
 
     location /status {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://sfkit.terra.bio</loc>
+    </url>
+    <url>
+        <loc>https://sfkit.terra.bio/workflows</loc>
+    </url>
+</urlset>


### PR DESCRIPTION
I'm adjusting Nginx config to address a few ZAP issues, as well as improve CDN caching behavior.

Issues addressed:
- `Content-Security-Policy` header was adjusted to be more in line with the "Starter Policy" as per https://content-security-policy.com, which also addresses warnings about missing CSP components highlighted in ZAP
- `Cache-Control` header is set to `no-cache, no-store, must-revalidate` for the index page and a few other resources (like `appConfig.json`) that may change from deployment to deployment, without changing their file path/name
- `Cache-Control` header is set to `max-age=31536000, immutable` (longest duration) for anything under `/assets`, as well as `/latest/meta-data`. This is because those assets are truly immutable, and when app source is recompiled the hashes in their file names change, thus creating new resources to be fetched from origin the server (Nginx)
- `Pragma: no-cache` header was removed, since it's been deprecated.
- Turned off access logging for `/version` endpoint, which is only used by healthchecks and pollutes the log
- Added `/latest/meta-data` endpoint that returns 404, to prevent a (false-positive) ZAP warning about exposed internal metadata endpoint
- Added minimal `robots.txt` and `sitemap.xml` for search engine indexing (also reported by ZAP previously)
- Removed non-existent error page endpoints

Note that after these fixes, UI scan with ajax spider in ZAP desktop version now returns 0 findings. However, baseline scan via Docker still returns a number of findings that all appear to be false-positives.

https://broadworkbench.atlassian.net/browse/SMC-4