### PR TITLE
[SMC-13] Fix Nginx config path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ RUN echo "{\"appVersion\": \"$APP_VERSION\", \"buildVersion\": \"$BUILD_VERSION\
 
 FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:distroless
 
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/nginx.default.conf
 COPY --from=build /app/dist /usr/share/nginx/html/


### PR DESCRIPTION
Recent version of base Nginx image from Chainguard (`cgr.dev/chainguard/nginx` that our blessed Nginx image uses) seems to have introduced an incompatible change, where the path to the server-specific Nginx config file changed from `/etc/nginx/conf.d/default.conf` to `/etc/nginx/conf.d/nginx.default.conf`. As such, our old configuration inside Dockerfile has stopped working (with status endpoints missing, and no security headers applied etc).

https://broadworkbench.atlassian.net/browse/SMC-13