### PR TITLE
[SMC-16] Fix repeated requests to fetch studies

### DIFF
--- a/src/hooks/useTerra.ts
+++ b/src/hooks/useTerra.ts
@@ -1,12 +1,15 @@
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 import { AppContext } from "../App";
 
 export const useTerra = () => {
     const { apiBaseUrl } = useContext(AppContext);
-    const url = new URL(apiBaseUrl);
 
-    return {
-        onTerra: url.hostname.endsWith('.broadinstitute.org'),
-        apiBaseUrl: url,
-    };
+    return useMemo(() => {
+        const url = new URL(apiBaseUrl);
+
+        return {
+            onTerra: url.hostname.endsWith('.broadinstitute.org'),
+            apiBaseUrl: url,
+        };
+    }, [apiBaseUrl]);
 };

--- a/src/pages/Studies.tsx
+++ b/src/pages/Studies.tsx
@@ -1,14 +1,14 @@
-import React, { useEffect, useRef, useState } from "react";
+import { DocumentData, doc, onSnapshot } from "firebase/firestore";
+import React, { useEffect, useState } from "react";
+import { useAuth } from "react-oidc-context";
+import LoginButton from "../components/LoginButton";
 import ChooseWorkflow from "../components/studies/ChooseWorkflow";
 import DisplayStudy from "../components/studies/DisplayStudy";
-import { Study } from "../types/study";
-import { DocumentData, doc, onSnapshot } from "firebase/firestore";
 import { getDb } from "../hooks/firebase";
-import LoginButton from "../components/LoginButton";
-import useGenerateAuthHeaders from "../hooks/useGenerateAuthHeaders";
 import useFirestore from "../hooks/useFirestore";
-import { useAuth } from "react-oidc-context";
+import useGenerateAuthHeaders from "../hooks/useGenerateAuthHeaders";
 import { useTerra } from "../hooks/useTerra";
+import { Study } from "../types/study";
 
 const Studies: React.FC = () => {
   const { onTerra, apiBaseUrl } = useTerra();
@@ -18,7 +18,6 @@ const Studies: React.FC = () => {
   const [myStudies, setMyStudies] = useState<Study[] | null>(null);
   const [otherStudies, setOtherStudies] = useState<Study[] | null>(null);
   const [user, setUser] = useState<DocumentData | null>(null);
-  const isFetchingPublicStudiesRef = useRef(false);
 
   const headers = useGenerateAuthHeaders();
   const idToken = useAuth().user?.id_token || "";
@@ -59,19 +58,14 @@ const Studies: React.FC = () => {
       return;
     }
     const fetchPublicStudies = async () => {
-      if (!isFetchingPublicStudiesRef.current) {
-        isFetchingPublicStudiesRef.current = true;
-        try {
-          const response = await fetch(`${apiBaseUrl}/api/public_studies`, {
-            headers,
-          });
-          const data = await response.json();
-          setOtherStudies(data.studies);
-        } catch (error) {
-          console.error("Error fetching public studies:", error);
-        } finally {
-          isFetchingPublicStudiesRef.current = false;
-        }
+      try {
+        const response = await fetch(`${apiBaseUrl}/api/public_studies`, {
+          headers,
+        });
+        const data = await response.json();
+        setOtherStudies(data.studies);
+      } catch (error) {
+        console.error("Error fetching public studies:", error);
       }
     };
 

--- a/src/pages/Studies.tsx
+++ b/src/pages/Studies.tsx
@@ -24,6 +24,11 @@ const Studies: React.FC = () => {
   const idToken = useAuth().user?.id_token || "";
   const { userId } = useFirestore();
 
+  console.log("apiBaseUrl", apiBaseUrl);
+  console.log("onTerra", onTerra);
+  console.log("idToken", idToken);
+  console.log("headers", headers);
+
   useEffect(() => {
     if (userId) {
       const unsubscribe = onSnapshot(doc(getDb(), "users", userId), (doc) => {
@@ -37,6 +42,7 @@ const Studies: React.FC = () => {
   }, [userId]);
 
   useEffect(() => {
+    console.log("useEffect fetchMyStudies");
     if (idToken) {
       const fetchMyStudies = async () => {
         try {

--- a/src/pages/Studies.tsx
+++ b/src/pages/Studies.tsx
@@ -38,7 +38,6 @@ const Studies: React.FC = () => {
 
   useEffect(() => {
     if (idToken) {
-      console.log("useEffect fetchMyStudies");
       const fetchMyStudies = async () => {
         try {
           const response = await fetch(`${apiBaseUrl}/api/my_studies`, {
@@ -65,7 +64,6 @@ const Studies: React.FC = () => {
     }
     const fetchPublicStudies = async () => {
       if (!isFetchingPublicStudiesRef.current) {
-        console.log("useEffect fetchPublicStudies");
         isFetchingPublicStudiesRef.current = true;
         try {
           const response = await fetch(`${apiBaseUrl}/api/public_studies`, {

--- a/src/pages/Studies.tsx
+++ b/src/pages/Studies.tsx
@@ -24,11 +24,6 @@ const Studies: React.FC = () => {
   const idToken = useAuth().user?.id_token || "";
   const { userId } = useFirestore();
 
-  console.log("apiBaseUrl", apiBaseUrl);
-  console.log("onTerra", onTerra);
-  console.log("idToken", idToken);
-  console.log("headers", headers);
-
   useEffect(() => {
     if (userId) {
       const unsubscribe = onSnapshot(doc(getDb(), "users", userId), (doc) => {
@@ -42,8 +37,8 @@ const Studies: React.FC = () => {
   }, [userId]);
 
   useEffect(() => {
-    console.log("useEffect fetchMyStudies");
     if (idToken) {
+      console.log("useEffect fetchMyStudies");
       const fetchMyStudies = async () => {
         try {
           const response = await fetch(`${apiBaseUrl}/api/my_studies`, {
@@ -70,6 +65,7 @@ const Studies: React.FC = () => {
     }
     const fetchPublicStudies = async () => {
       if (!isFetchingPublicStudiesRef.current) {
+        console.log("useEffect fetchPublicStudies");
         isFetchingPublicStudiesRef.current = true;
         try {
           const response = await fetch(`${apiBaseUrl}/api/public_studies`, {

--- a/src/pages/Studies.tsx
+++ b/src/pages/Studies.tsx
@@ -80,7 +80,7 @@ const Studies: React.FC = () => {
     };
 
     fetchPublicStudies();
-  }, [apiBaseUrl, headers, onTerra, otherStudies]);
+  }, [apiBaseUrl, onTerra, headers]);
 
   useEffect(() => {
     if (myStudies && myStudies.length > 0) {

--- a/src/pages/Studies.tsx
+++ b/src/pages/Studies.tsx
@@ -58,10 +58,6 @@ const Studies: React.FC = () => {
     if ((!headers.Authorization || headers.Authorization === "Bearer ") && onTerra) {
       return;
     }
-    // we don't need to fetch public studies if we already have them
-    if (otherStudies && otherStudies.length > 0) {
-      return;
-    }
     const fetchPublicStudies = async () => {
       if (!isFetchingPublicStudiesRef.current) {
         isFetchingPublicStudiesRef.current = true;


### PR DESCRIPTION
There’s a bug in sfkit UI that keeps fetching studies in an infinite loop. And it's increased in frequency when the study list is empty. This puts unnecessary burden on the backend.

The issue was introduced because of the use of `new URL` operator in `useTerra` React hook, which then created a new URL object on each use, resulting in infinite re-renders of Studies component. This PR memoizes that through `useMemo` hook instead.

Additionally, when the list of public studies was empty, it also resulted in an infinite loop, due to unnecessary checks and dependency on `otherStudies` variable, which changed on every re-render as a result.

https://broadworkbench.atlassian.net/browse/SMC-16