### PR TITLE
[SMC-19] Fix onTerra condition based on hostname

### DIFF
--- a/src/hooks/useTerra.ts
+++ b/src/hooks/useTerra.ts
@@ -1,6 +1,8 @@
 import { useContext, useMemo } from "react";
 import { AppContext } from "../App";
 
+const terraRe = /^(sfkitui\.dsde-(dev|staging|prod)\.broadinstitute\.org|sfkit\.terra\.bio)$/;
+
 export const useTerra = () => {
     const { apiBaseUrl } = useContext(AppContext);
 
@@ -8,7 +10,7 @@ export const useTerra = () => {
         const url = new URL(apiBaseUrl);
 
         return {
-            onTerra: url.hostname.endsWith('.broadinstitute.org'),
+            onTerra: terraRe.test(url.hostname),
             apiBaseUrl: url,
         };
     }, [apiBaseUrl]);


### PR DESCRIPTION
Currently, sfkit UI is tailored to Terra based on whether the hostname ends with `.broadinstitute.org`. However, this assumption breaks down for the production vanity host `sfkit.terra.bio`.

Now, we do a strict regex match instead.

https://broadworkbench.atlassian.net/browse/SMC-19