### PR TITLE
[SMC-21] Add button to check NAT type

### DIFF
--- a/src/components/IdleStatusMonitor.tsx
+++ b/src/components/IdleStatusMonitor.tsx
@@ -11,7 +11,7 @@ const idleEvents = ['click', 'keydown'];
 export const IdleStatusMonitor = () => {
   const auth = useAuth();
   const headers = useGenerateAuthHeaders();
-  const { onTerra, apiBaseUrl } = useTerra();
+  const { onTerra, samApiUrl } = useTerra();
   const timeoutId = useRef<number>();
   const navigate = useNavigate();
 
@@ -21,10 +21,7 @@ export const IdleStatusMonitor = () => {
     (async () => {
       if (!onTerra || !auth.isAuthenticated || timeoutId.current) return;
 
-      const samHostname = apiBaseUrl.hostname.replace(/^[^.]+/, 'sam');
-      const samGroupUrl = `https://${samHostname}/api/groups/v1`;
-
-      const res = await fetch(samGroupUrl, { headers });
+      const res = await fetch(`${samApiUrl}/groups/v1`, { headers });
       const groups = await res.json() as { groupName: string }[];
       const isTimeoutEnabled = groups.some(g => g.groupName === 'session_timeout');
       if (!isTimeoutEnabled) return;
@@ -59,7 +56,7 @@ export const IdleStatusMonitor = () => {
         timeoutId.current = undefined;
       };
     })().catch(console.error);
-  }, [auth.isAuthenticated, onTerra, apiBaseUrl, headers, navigate, signOut]);
+  }, [auth.isAuthenticated, onTerra, samApiUrl, headers, navigate, signOut]);
 
   return <div />;
 };

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -261,7 +261,7 @@ const InstructionArea: React.FC<Props> = ({
           <div>
             <p>
               You will also need to check the type of Network Address Translation (NAT) on your machine.
-              This is done automatically by the sfkit CLI. However, if you use it on the same machine,
+              This is done automatically by the <i>sfkit</i> CLI. However, if you use it on the same machine,
               you can also click the following button:
             </p>
             <p className="text-center mt-3">
@@ -285,7 +285,7 @@ const InstructionArea: React.FC<Props> = ({
                   </>
                 ) : (
                   <>
-                    Your NAT is compatible with the sfkit CLI.
+                    Your NAT is compatible with the <i>sfkit</i> CLI.
                   </>
                 )}
               </div>
@@ -325,7 +325,7 @@ const InstructionArea: React.FC<Props> = ({
             </li>
             <li>
               <p>
-                Install sfkit CLI manually using the following script:
+                Install <i>sfkit</i> CLI manually using the following script:
               </p>
               {renderCode("curl -sL https://github.com/hcholab/sfkit/releases/latest/download/install.sh | bash", "87%")}
               <p>

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -268,26 +268,35 @@ const InstructionArea: React.FC<Props> = ({
               <button
                 className="btn btn-primary btn-sm"
                 onClick={checkNatType}
-                disabled={isCheckingNatType}
+                disabled={isCheckingNatType === true}
               >
                 {isCheckingNatType ? 'Checking NAT Type...' : 'Check NAT Type'}
               </button>
 
             </p>
-            {isSymmetricNat !== null && (
-              <div className={ "alert mt-2 alert-" + (isSymmetricNat ? "danger" : "info") }>
-                { isSymmetricNat ? (
+            {isCheckingNatType === false && (
+              <div className={ "alert mt-2 alert-" + (
+                isSymmetricNat === true ? "danger" : (
+                  isSymmetricNat === false ? "info" : "warning"
+                )
+              )}>
+                { isSymmetricNat === true ? (
                   <>
                     <b>Error:</b> Your NAT is <i>symmetric</i>.
                     This means the CLI won't be able to establish peer-to-peer connections
                     with other participant machines. You will need to either set up port forwarding,
                     use a different network, or configure your network to use a different NAT type.
                   </>
-                ) : (
+                ) : (isSymmetricNat === false ? (
                   <>
                     Your NAT is compatible with the <i>sfkit</i> CLI.
                   </>
-                )}
+                ) : (
+                  <>
+                    <b>Warning:</b> We were unable to determine the type of your NAT.
+                    Please run <i>sfkit</i> CLI as explained below, which will check it automatically.
+                  </>
+                ))}
               </div>
             )}
           </div>

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -6,6 +6,7 @@ import { ParameterGroup } from "../../types/study";
 import ConfigureComputeEnvModal from "./ConfigureStudyModal";
 import SubTaskContainer from "./SubTaskContainer";
 import TaskElement from "./TaskElement";
+import { useCheckNatType } from "../../hooks/useCheckNatType";
 
 interface Props {
   personalParameters: ParameterGroup;
@@ -52,8 +53,9 @@ const InstructionArea: React.FC<Props> = ({
   const [plotSrc, setPlotSrc] = useState("");
   const [isFetchingPlot, setIsFetchingPlot] = useState(false);
   const [hoveredButton, setHoveredButton] = useState<string | null>(null);
-  const plotSrcRef = useRef("");
+  const { checkNatType, isSymmetricNat, isCheckingNatType } = useCheckNatType();
   const headers = useGenerateAuthHeaders();
+  const plotSrcRef = useRef("");
 
   const fetchPlotFile = useCallback(async () => {
     try {
@@ -220,6 +222,7 @@ const InstructionArea: React.FC<Props> = ({
             </a>
             on your machine.
           </p>
+          <div className="my-2" style={{ borderTop: 'dashed #ccc' }}/>
           <p>
             { onTerra ? (
               <>
@@ -242,7 +245,7 @@ const InstructionArea: React.FC<Props> = ({
                 the <b><i>absolute path</i></b> to the service account key downloaded to your machine.
               </p>
               <div className="alert alert-warning mt-2">
-                <strong>Warning:</strong> This key contains sensitive credentials.
+                <b>Warning:</b> This key contains sensitive credentials.
                 Store it in a secure out-of-the-way location on your computer, such as
                 the <code>~/.config/gcloud/</code> directory.
                 Never share this key or commit it to version control.
@@ -254,6 +257,42 @@ const InstructionArea: React.FC<Props> = ({
               Download { onTerra ? "Service Account Key" : "Auth Key" }
             </button>
           </p>
+
+          <div>
+            <p>
+              You will also need to check the type of Network Address Translation (NAT) on your machine.
+              This is done automatically by the sfkit CLI. However, if you use it on the same machine,
+              you can also click the following button:
+            </p>
+            <p className="text-center mt-3">
+              <button
+                className="btn btn-primary btn-sm"
+                onClick={checkNatType}
+                disabled={isCheckingNatType}
+              >
+                {isCheckingNatType ? 'Checking NAT Type...' : 'Check NAT Type'}
+              </button>
+
+            </p>
+            {isSymmetricNat !== null && (
+              <div className={ "alert mt-2 alert-" + (isSymmetricNat ? "danger" : "info") }>
+                { isSymmetricNat ? (
+                  <>
+                    <b>Error:</b> Your NAT is <i>symmetric</i>.
+                    This means the CLI won't be able to establish peer-to-peer connections
+                    with other participant machines. You will need to either set up port forwarding,
+                    use a different network, or configure your network to use a different NAT type.
+                  </>
+                ) : (
+                  <>
+                    Your NAT is compatible with the sfkit CLI.
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="my-2" style={{ borderTop: 'dashed #ccc' }}/>
           <p>
             To start <i>sfkit</i> protocol on your machine, first set some environment variables:
           </p>

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -208,9 +208,9 @@ const InstructionArea: React.FC<Props> = ({
             studyType={studyType}
             personalParameters={personalParameters}
           />
+          <hr/>OR<hr/>
         </>
       ) : null}
-      <hr/>OR<hr/>
       {status === "" ? (
         <div className="text-start">
           <p>

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -293,7 +293,7 @@ const InstructionArea: React.FC<Props> = ({
                   </>
                 ) : (
                   <>
-                    <b>Warning:</b> We were unable to determine the type of your NAT.
+                    <b>Warning:</b> We were unable to determine your NAT type.
                     Please run <i>sfkit</i> CLI as explained below, which will check it automatically.
                   </>
                 ))}

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -1,12 +1,12 @@
 import React, { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
+import { useCheckNatType } from "../../hooks/useCheckNatType";
 import useGenerateAuthHeaders from "../../hooks/useGenerateAuthHeaders";
 import { useTerra } from "../../hooks/useTerra";
 import { ParameterGroup } from "../../types/study";
 import ConfigureComputeEnvModal from "./ConfigureStudyModal";
 import SubTaskContainer from "./SubTaskContainer";
 import TaskElement from "./TaskElement";
-import { useCheckNatType } from "../../hooks/useCheckNatType";
 
 interface Props {
   personalParameters: ParameterGroup;

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -282,10 +282,21 @@ const InstructionArea: React.FC<Props> = ({
               )}>
                 { isSymmetricNat === true ? (
                   <>
-                    <b>Error:</b> Your NAT is <i>symmetric</i>.
-                    This means the CLI won't be able to establish peer-to-peer connections
-                    with other participant machines. You will need to either set up port forwarding,
-                    use a different network, or configure your network to use a different NAT type.
+                    <p>
+                      <b>Error:</b> Your NAT is <i>symmetric</i>.
+                      This means the CLI won't be able to establish peer-to-peer connections
+                      with other participant machines. You will need to either set up port forwarding,
+                      use a different network, or configure your network to use a different NAT type.
+                    </p>
+                    <p>
+                      For more information on why that is, please refer to this article explaining
+                      the nitty-gritty details: <a
+                        href="https://tailscale.com/blog/how-nat-traversal-works"
+                        className="text-decoration-none"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >How NAT Traversal Works</a>
+                    </p>
                   </>
                 ) : (isSymmetricNat === false ? (
                   <>

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -317,7 +317,7 @@ const InstructionArea: React.FC<Props> = ({
             To start <i>sfkit</i> protocol on your machine, first set some environment variables:
           </p>
           {renderCode(
-            `export SFKIT_API_URL=${apiBaseUrl}
+            `export SFKIT_API_URL=${apiBaseUrl}/api
             export SFKIT_STUDY_ID=${study_id}
             export SFKIT_DATA_PATH=/path/to/data_dir`
           )}

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -232,7 +232,7 @@ const InstructionArea: React.FC<Props> = ({
               <>
                 On your machine, you
               </>
-            )} will also need to download <code>
+            )} will need to download <code>
             { onTerra ? "service_account_key.json" : "auth_key.txt" }
             </code> { onTerra && "and run the following command " }
             to authenticate the <i>sfkit</i> command-line interface:

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -134,12 +134,12 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
             setUploadProgress(({ [filePath]: _, ...p }) => p);
             resolve();
           } else {
-            setUploadError(`Error uploading file ${filePath}: ${xhr.status} ${xhr.statusText} ${xhr.responseText.trim()}`);
+            setUploadError(`Error uploading file '${filePath}': ${xhr.status} ${xhr.statusText} ${xhr.responseText.trim()}`);
           }
         };
 
         xhr.onerror = () => {
-          setUploadError(`Network error uploading file ${filePath}`);
+          setUploadError(`Network error uploading file '${filePath}'`);
         };
 
         xhr.send(f);

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -51,7 +51,7 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
 
     const listWorkspaces = async () => {
       try {
-        const url = `${rawlsApiUrl}/workspaces?fields=accessLevel,workspace.namespace,workspace.name,workspace.cloudPlatform,workspace.bucketName`;
+        const url = `${rawlsApiUrl}/workspaces?fields=accessLevel,workspace.namespace,workspace.name,workspace.cloudPlatform,workspace.googleProject,workspace.bucketName`;
         const res = dev
           ? { ok: true, json: async () => (await import("./workspaces.json")).default }
           : await fetch(url, { headers });

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -172,7 +172,7 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
         inputs: {
           "sfkit.study_id": "this.study_id",
           "sfkit.data": "this.data",
-          "sfkit.api_url": `\"${apiBaseUrl}\"`,
+          "sfkit.api_url": `\"${apiBaseUrl}/api\"`,
         },
         outputs: {},
         methodConfigVersion: 1,

--- a/src/hooks/useCheckNatType.ts
+++ b/src/hooks/useCheckNatType.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react';
+
+export const useCheckNatType = () => {
+  const [isSymmetricNat, setIsSymmetricNat] = useState<boolean | null>(null);
+  const [isCheckingNatType, setIsCheckingNatType] = useState(false);
+
+  const checkNatType = useCallback(async () => {
+    setIsCheckingNatType(true);
+
+    const candidates: Record<number, number[]> = {};
+    const pc = new RTCPeerConnection({
+      iceServers: [
+        { urls: 'stun:stun.l.google.com:19302' },
+        { urls: 'stun:stun.syncthing.net:3478' },
+      ],
+    });
+
+    const finalizeNatType = () => {
+      if (Object.keys(candidates).length === 1) {
+        setIsSymmetricNat(Object.values(candidates)[0].length > 1);
+      }
+      setIsCheckingNatType(false);
+      pc.close();
+    }
+
+    pc.onicecandidate = (e) => {
+      const c = e.candidate;
+      if (c && c.type === 'srflx' && c.relatedPort !== null && c.port !== null) {
+        if (!candidates[c.relatedPort]) {
+          candidates[c.relatedPort] = [c.port];
+        } else {
+          candidates[c.relatedPort].push(c.port);
+        }
+        return;
+      } else if (!c) {
+        finalizeNatType();
+      }
+    };
+
+    pc.createDataChannel("stun");
+    await pc.setLocalDescription(await pc.createOffer());
+    setTimeout(finalizeNatType, 5000);
+  }, []);
+
+  return { checkNatType, isSymmetricNat, isCheckingNatType };
+};

--- a/src/hooks/useCheckNatType.ts
+++ b/src/hooks/useCheckNatType.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 
 export const useCheckNatType = () => {
   const [isSymmetricNat, setIsSymmetricNat] = useState<boolean | null>(null);
-  const [isCheckingNatType, setIsCheckingNatType] = useState(false);
+  const [isCheckingNatType, setIsCheckingNatType] = useState<boolean | null>(null);
 
   const checkNatType = useCallback(async () => {
     setIsCheckingNatType(true);

--- a/src/hooks/useTerra.ts
+++ b/src/hooks/useTerra.ts
@@ -13,7 +13,7 @@ export const useTerra = () => {
 
         return {
             onTerra: dev || terraRe.test(url.hostname),
-            apiBaseUrl: url,
+            apiBaseUrl,
             rawlsApiUrl: `https://${hostname.replace(/^sfkit\./, "rawls.")}/api`,
             samApiUrl: `https://${hostname.replace(/^sfkit\./, "sam.")}/api`,
             dev,

--- a/src/pages/studies/Study.tsx
+++ b/src/pages/studies/Study.tsx
@@ -15,7 +15,7 @@ import { getDb } from "../../hooks/firebase";
 import useGenerateAuthHeaders from "../../hooks/useGenerateAuthHeaders";
 import { useTerra } from "../../hooks/useTerra";
 
-const fetchStudy = async (apiBaseUrl: string | URL, study_id: string, headers: Record<string, string>) => {
+const fetchStudy = async (apiBaseUrl: string, study_id: string, headers: Record<string, string>) => {
   try {
     const response = await fetch(`${apiBaseUrl}/api/study?study_id=${study_id}`, {
       method: "GET",

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -1,6 +1,6 @@
 export const submitStudyParameters = async (
   event: React.FormEvent<HTMLFormElement>,
-  apiBaseUrl: string | URL,
+  apiBaseUrl: string,
   studyId: string,
   headers: HeadersInit,
   setFeedback?: (feedback: string) => void,


### PR DESCRIPTION
This PR adds UI elements to help a user check their NAT type, before they go through the trouble of configuring the CLI, when they're running it outside of Terra.

We also fix sfkit `apiBaseUrl` handling, which was not fully correctly set in https://github.com/hcholab/sfkit-react/pull/51.

Next, we add missing `workspace.googleProject` attribute when listing workspaces.

Finally, we fix workspace upload logic such that a user cannot start a workflow until all files are uploaded successfully (and showing the errors, if any).

https://broadworkbench.atlassian.net/browse/SMC-21

![image](https://github.com/user-attachments/assets/34ef3d03-548b-4d50-b4d9-549de457857f)
![image](https://github.com/user-attachments/assets/2d0c5b5e-d045-4269-9658-7cdc7aca0cff)
![image](https://github.com/user-attachments/assets/cb3a92b8-0ac9-4b3b-8b91-6dc475a24127)
![image](https://github.com/user-attachments/assets/00b51d67-d111-48a3-b6bc-d67259b082a9)
![image](https://github.com/user-attachments/assets/731b7b2c-4ce3-409e-ae30-69d45b7eb040)

