### PR TITLE
[SMC-28] Restore protocol start validation

### DIFF
--- a/src/components/studies/ConfigureStudyModal.tsx
+++ b/src/components/studies/ConfigureStudyModal.tsx
@@ -6,7 +6,7 @@ import InstructionSteps from "./InstructionSteps";
 interface ConfigureStudyModalProps {
   handleShow: () => void;
   handleClose: () => void;
-  handleStartWorkflow: () => void;
+  handleStartWorkflow: () => Promise<void>;
   showModal: boolean;
   demo: boolean;
   studyId: string;

--- a/src/components/studies/ConfigureStudyModal.tsx
+++ b/src/components/studies/ConfigureStudyModal.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { Button, Modal } from "react-bootstrap";
+import { DryRunFunc } from "../../pages/studies/Study";
 import { ParameterGroup } from "../../types/study";
 import InstructionSteps from "./InstructionSteps";
 
 interface ConfigureStudyModalProps {
   handleShow: () => void;
   handleClose: () => void;
-  handleStartWorkflow: () => Promise<void>;
+  handleStartWorkflow: DryRunFunc;
   showModal: boolean;
   demo: boolean;
   studyId: string;

--- a/src/components/studies/ConfigureStudyModal.tsx
+++ b/src/components/studies/ConfigureStudyModal.tsx
@@ -13,6 +13,7 @@ interface ConfigureStudyModalProps {
   studyId: string;
   studyType: string;
   personalParameters: ParameterGroup;
+  failStatus: string;
 }
 
 const ConfigureComputeEnvModal: React.FC<ConfigureStudyModalProps> = ({
@@ -24,6 +25,7 @@ const ConfigureComputeEnvModal: React.FC<ConfigureStudyModalProps> = ({
   studyId,
   studyType,
   personalParameters,
+  failStatus,
 }) => {
   return (
     <>
@@ -42,6 +44,7 @@ const ConfigureComputeEnvModal: React.FC<ConfigureStudyModalProps> = ({
             studyType={studyType}
             parameters={personalParameters}
             handleStartWorkflow={handleStartWorkflow}
+            failStatus={failStatus}
           />
         </Modal.Body>
         <Modal.Footer>

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -54,6 +54,7 @@ const InstructionArea: React.FC<Props> = ({
   const [plotSrc, setPlotSrc] = useState("");
   const [isFetchingPlot, setIsFetchingPlot] = useState(false);
   const [hoveredButton, setHoveredButton] = useState<string | null>(null);
+  const [isStudyValid, setIsStudyValid] = useState<boolean>();
   const { checkNatType, isSymmetricNat, isCheckingNatType } = useCheckNatType();
   const headers = useGenerateAuthHeaders();
   const plotSrcRef = useRef("");
@@ -318,9 +319,22 @@ const InstructionArea: React.FC<Props> = ({
             To start <i>sfkit</i> protocol on your machine, first check that the study is set up correctly:
           </p>
           <p className="text-center">
-            <button className="btn btn-primary btn-sm" onClick={() => handleStartWorkflow({ dryRun: true })}>
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={() => {
+                handleStartWorkflow({ dryRun: true })
+                  .then(() => setIsStudyValid(true))
+                  .catch(() => setIsStudyValid(false))
+              }}
+            >
               Validate Study
             </button>
+            <span
+              className={"ms-2 " + (isStudyValid ? "text-success" : "text-danger")}
+              style={{ fontSize: '1.5em', verticalAlign: 'middle' }}
+            >
+              {isStudyValid === true ? "✓" : (isStudyValid === false ? "✗" : " ") }
+            </span>
           </p>
           <p>
             Then, set some environment variables:

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -335,7 +335,7 @@ const InstructionArea: React.FC<Props> = ({
             the <b><i>absolute path</i></b> to the input data directory on your machine.
           </p>
           <p>
-            Then, either:
+            Finally, either:
           </p>
           <ol>
             <li>

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -24,7 +24,7 @@ interface Props {
   showManhattanDiv: boolean;
   imageSrc: string;
   imageLabel: string;
-  showFailStatus: boolean;
+  failStatus: string;
   handleStartWorkflow: DryRunFunc;
   handleDownloadAuthKey: () => void;
 }
@@ -41,7 +41,7 @@ const InstructionArea: React.FC<Props> = ({
   tasks,
   showDownloadDiv,
   showManhattanDiv,
-  showFailStatus,
+  failStatus,
   handleStartWorkflow,
   handleDownloadAuthKey,
 }) => {
@@ -279,7 +279,7 @@ const InstructionArea: React.FC<Props> = ({
             {isCheckingNatType === false && (
               <div className={ "alert mt-2 alert-" + (
                 isSymmetricNat === true ? "danger" : (
-                  isSymmetricNat === false ? "info" : "warning"
+                  isSymmetricNat === false ? "success" : "warning"
                 )
               )}>
                 { isSymmetricNat === true ? (
@@ -302,7 +302,7 @@ const InstructionArea: React.FC<Props> = ({
                   </>
                 ) : (isSymmetricNat === false ? (
                   <>
-                    Your NAT is compatible with the <i>sfkit</i> CLI.
+                    ✔ Your NAT is compatible with the <i>sfkit</i> CLI.
                   </>
                 ) : (
                   <>
@@ -322,6 +322,7 @@ const InstructionArea: React.FC<Props> = ({
             <button
               className="btn btn-primary btn-sm"
               onClick={() => {
+                setIsStudyValid(undefined);
                 handleStartWorkflow({ dryRun: true })
                   .then(() => setIsStudyValid(true))
                   .catch(() => setIsStudyValid(false))
@@ -329,13 +330,21 @@ const InstructionArea: React.FC<Props> = ({
             >
               Validate Study
             </button>
-            <span
-              className={"ms-2 " + (isStudyValid ? "text-success" : "text-danger")}
-              style={{ fontSize: '1.5em', verticalAlign: 'middle' }}
-            >
-              {isStudyValid === true ? "✓" : (isStudyValid === false ? "✗" : " ") }
-            </span>
           </p>
+          { isStudyValid === true ? (
+              <div className="alert alert-success text-center">
+                ✔ Study is valid.
+              </div>
+            ) : (
+              isStudyValid === false ? (
+                <div className="alert alert-danger">
+                  <b>Error:</b> {failStatus}
+                </div>
+              ) : (
+                <></>
+              )
+            )
+          }
           <p>
             Then, set some environment variables:
           </p>
@@ -426,7 +435,7 @@ const InstructionArea: React.FC<Props> = ({
               )}
             </>
           )}
-          {showFailStatus && <div className="text-start alert alert-danger">Study execution has failed.</div>}{" "}
+          {failStatus && <div className="text-start alert alert-danger">Study execution has failed: {failStatus}</div>}{" "}
         </div>
       ) : null}
     </div>

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { useCheckNatType } from "../../hooks/useCheckNatType";
 import useGenerateAuthHeaders from "../../hooks/useGenerateAuthHeaders";
 import { useTerra } from "../../hooks/useTerra";
+import { DryRunFunc } from "../../pages/studies/Study";
 import { ParameterGroup } from "../../types/study";
 import ConfigureComputeEnvModal from "./ConfigureStudyModal";
 import SubTaskContainer from "./SubTaskContainer";
@@ -24,7 +25,7 @@ interface Props {
   imageSrc: string;
   imageLabel: string;
   showFailStatus: boolean;
-  handleStartWorkflow: () => Promise<void>;
+  handleStartWorkflow: DryRunFunc;
   handleDownloadAuthKey: () => void;
 }
 

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -301,9 +301,9 @@ const InstructionArea: React.FC<Props> = ({
                     </p>
                   </>
                 ) : (isSymmetricNat === false ? (
-                  <>
+                  <div className="text-center">
                     ✔ Your NAT is compatible with the <i>sfkit</i> CLI.
-                  </>
+                  </div>
                 ) : (
                   <>
                     <b>Warning:</b> We were unable to determine your NAT type.

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -315,7 +315,7 @@ const InstructionArea: React.FC<Props> = ({
 
           <div className="my-2" style={{ borderTop: 'dashed #ccc' }}/>
           <p>
-            To start <i>sfkit</i> protocol on your machine, first check that all protocol parameters are set correctly:
+            To start <i>sfkit</i> protocol on your machine, first check that the study is set up correctly:
           </p>
           <p className="text-center">
             <button className="btn btn-primary btn-sm" onClick={() => handleStartWorkflow({ dryRun: true })}>

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -209,6 +209,7 @@ const InstructionArea: React.FC<Props> = ({
             studyId={study_id}
             studyType={studyType}
             personalParameters={personalParameters}
+            failStatus={failStatus}
           />
           <hr/>OR<hr/>
         </>

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -24,7 +24,7 @@ interface Props {
   imageSrc: string;
   imageLabel: string;
   showFailStatus: boolean;
-  handleStartWorkflow: () => void;
+  handleStartWorkflow: () => Promise<void>;
   handleDownloadAuthKey: () => void;
 }
 

--- a/src/components/studies/InstructionArea.tsx
+++ b/src/components/studies/InstructionArea.tsx
@@ -315,7 +315,15 @@ const InstructionArea: React.FC<Props> = ({
 
           <div className="my-2" style={{ borderTop: 'dashed #ccc' }}/>
           <p>
-            To start <i>sfkit</i> protocol on your machine, first set some environment variables:
+            To start <i>sfkit</i> protocol on your machine, first check that all protocol parameters are set correctly:
+          </p>
+          <p className="text-center">
+            <button className="btn btn-primary btn-sm" onClick={() => handleStartWorkflow({ dryRun: true })}>
+              Validate Study
+            </button>
+          </p>
+          <p>
+            Then, set some environment variables:
           </p>
           {renderCode(
             `export SFKIT_API_URL=${apiBaseUrl}/api

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -205,9 +205,9 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
         inputs: {
           "sfkit.study_id": "this.study_id",
           "sfkit.data": "this.data",
-          "sfkit.api_url": `\"${apiBaseUrl}/api\"`,
           "sfkit.num_cores": params.NUM_CPUS,
           "sfkit.boot_disk_size_gb": params.BOOT_DISK_SIZE,
+          "sfkit.api_url": `\"${apiBaseUrl}/api\"`,
         },
         outputs: {},
         methodConfigVersion: 2,

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -597,10 +597,9 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
         </Accordion.Collapse>
       </Card>
       <div className="d-flex justify-content-center mt-3">
-        <Button variant="success" onClick={async () => {
-          onTerra ? await handleStartTerraWorkflow() : handleStartNonTerraWorkflow();
-          location.reload();
-        }} disabled={onTerra && !workspaceBucketUrl}>
+        <Button variant="success" onClick={
+          onTerra ? handleStartTerraWorkflow : handleStartNonTerraWorkflow
+        } disabled={onTerra && !workspaceBucketUrl}>
           Begin {studyType} Workflow
         </Button>
       </div>

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -18,7 +18,7 @@ interface InstructionStepsProps {
   studyId: string;
   studyType: string;
   parameters: ParameterGroup;
-  handleStartWorkflow: () => void;
+  handleStartWorkflow: () => Promise<void>;
 }
 
 type Workspace = {

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -601,7 +601,7 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
         <Button variant="success" onClick={async () => {
           onTerra ? await handleStartTerraWorkflow() : await handleStartNonTerraWorkflow();
           location.reload();
-        }} disabled={false && onTerra && !workspaceBucketUrl}>
+        }} disabled={onTerra && !workspaceBucketUrl}>
           Begin {studyType} Workflow
         </Button>
       </div>

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -599,7 +599,7 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
       </Card>
       <div className="d-flex justify-content-center mt-3">
         <Button variant="success" onClick={async () => {
-          onTerra ? await handleStartTerraWorkflow() : await handleStartNonTerraWorkflow();
+          await (onTerra ? handleStartTerraWorkflow() : handleStartNonTerraWorkflow());
           location.reload();
         }} disabled={onTerra && !workspaceBucketUrl}>
           Begin {studyType} Workflow

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -44,10 +44,15 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
   const [submitFeedback, setSubmitFeedback] = useState<string | null>(null);
   const headers = useGenerateAuthHeaders();
 
-  Object.entries(parameters).forEach(([key, value]) => {
-    if (Array.isArray(value)) return;
-    setParams(p => ({ ...p, [key]: value.value }));
-  });
+  useEffect(() => {
+    const newParams: Record<string, string | number> = {};
+    Object.entries(parameters).forEach(([key, value]) => {
+      if (!Array.isArray(value)) {
+        newParams[key] = value.value;
+      }
+    });
+    setParams(newParams);
+  }, [parameters]);
 
   useEffect(() => {
     setSubmitFeedback(null);

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -19,6 +19,7 @@ interface InstructionStepsProps {
   studyId: string;
   studyType: string;
   parameters: ParameterGroup;
+  failStatus: string;
   handleStartWorkflow: DryRunFunc;
 }
 
@@ -31,7 +32,7 @@ type Workspace = {
   accessLevel: string;
 };
 
-const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, studyType, parameters, handleStartWorkflow }) => {
+const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, studyType, parameters, failStatus, handleStartWorkflow }) => {
   const { onTerra, dev, apiBaseUrl, rawlsApiUrl, samApiUrl } = useTerra();
   const [activeKey, setActiveKey] = useState("0");
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
@@ -514,9 +515,9 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
 
                 <div className="text-center">
                   <div>{submitFeedback}</div>
-                  <button className="btn btn-primary" type="submit">
+                  <Button variant="primary" type="submit">
                     Confirm Virtual Machine Configuration
-                  </button>
+                  </Button>
                 </div>
               </form>
             </div>
@@ -583,9 +584,9 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
 
               <div className="text-center">
                 <div>{submitFeedback}</div>
-                <button className="btn btn-primary" type="submit">
+                <Button variant="primary" type="submit">
                   Confirm Post-Processing Configuration
-                </button>
+                </Button>
               </div>
             </form>
             <div className="text-end">
@@ -597,12 +598,18 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
         </Accordion.Collapse>
       </Card>
       <div className="d-flex justify-content-center mt-3">
-        <Button variant="success" onClick={
-          onTerra ? handleStartTerraWorkflow : handleStartNonTerraWorkflow
-        } disabled={onTerra && !workspaceBucketUrl}>
+        <Button variant="success" onClick={async () => {
+          onTerra ? await handleStartTerraWorkflow() : await handleStartNonTerraWorkflow();
+          location.reload();
+        }} disabled={false && onTerra && !workspaceBucketUrl}>
           Begin {studyType} Workflow
         </Button>
       </div>
+      {failStatus && (
+        <p className="text-center alert alert-danger mt-3">
+          Study execution has failed: {failStatus}
+        </p>
+      )}
     </Accordion>
   );
 };

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -594,7 +594,7 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
         </Accordion.Collapse>
       </Card>
       <div className="d-flex justify-content-center mt-3">
-        <Button variant="success" onClick={() =>
+        <Button variant="success" onClick={
           onTerra ? handleStartTerraWorkflow : handleStartNonTerraWorkflow
         } disabled={onTerra && !workspaceBucketUrl}>
           Begin {studyType} Workflow

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -594,10 +594,9 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
         </Accordion.Collapse>
       </Card>
       <div className="d-flex justify-content-center mt-3">
-        <Button variant="success" onClick={async () => {
-          await (onTerra ? handleStartTerraWorkflow() : handleStartNonTerraWorkflow());
-          location.reload();
-        }} disabled={onTerra && !workspaceBucketUrl}>
+        <Button variant="success" onClick={() =>
+          onTerra ? handleStartTerraWorkflow : handleStartNonTerraWorkflow
+        } disabled={onTerra && !workspaceBucketUrl}>
           Begin {studyType} Workflow
         </Button>
       </div>

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -87,8 +87,8 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
     listWorkspaces();
   }, [onTerra, dev, rawlsApiUrl, headers]);
 
-  const handleSubmitParameters = async (event: React.FormEvent<HTMLFormElement>) =>
-    submitStudyParameters(event, apiBaseUrl, studyId, headers, setSubmitFeedback, undefined, setParams);
+  const handleSubmitParameters = async (eventForm: React.FormEvent<HTMLFormElement> | FormData) =>
+    submitStudyParameters(eventForm, apiBaseUrl, studyId, headers, setSubmitFeedback, undefined, setParams);
 
   const filteredOptions = workspaces.filter(ws =>
     `${ws.namespace}/${ws.name}`.toLowerCase().includes(workspaceSearchTerm.toLowerCase())
@@ -163,6 +163,13 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
     } catch (error) {
       console.error("Error uploading files:", error);
     }
+  };
+
+  const handleStartNonTerraWorkflow = async () => {
+    const formData = new FormData();
+    formData.set("CREATE_VM", "Yes");
+    await handleSubmitParameters(formData);
+    await handleStartWorkflow();
   };
 
   const handleStartTerraWorkflow = async () => {
@@ -591,7 +598,7 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
       </Card>
       <div className="d-flex justify-content-center mt-3">
         <Button variant="success" onClick={async () => {
-          onTerra ? await handleStartTerraWorkflow() : handleStartWorkflow();
+          onTerra ? await handleStartTerraWorkflow() : handleStartNonTerraWorkflow();
           location.reload();
         }} disabled={onTerra && !workspaceBucketUrl}>
           Begin {studyType} Workflow

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -161,8 +161,8 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
 
     // Validate workflow
     const formData = new FormData();
-    formData.set("DATA_PATH", workspaceBucketUrl);
     formData.set("GCP_PROJECT", ws.googleProject);
+    formData.set("DATA_PATH", workspaceBucketUrl);
     await handleSubmitParameters(formData);
     await handleStartWorkflow();
 

--- a/src/components/studies/InstructionSteps.tsx
+++ b/src/components/studies/InstructionSteps.tsx
@@ -38,10 +38,16 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
   const [workspaceSearchTerm, setWorkspaceSearchTerm] = useState("");
   const [workspaceSearchDropdownOpen, setWorkspaceSearchDropdownOpen] = useState(false);
   const [workspaceBucketUrl, setWorkspaceBucketUrl] = useState<string>("");
+  const [params, setParams] = useState<Record<string, string | number>>({});
   const [uploadProgress, setUploadProgress] = useState<{ [key: string]: number }>({});
   const [uploadErrors, setUploadErrors] = useState<{ [key: string]: string }>({});
   const [submitFeedback, setSubmitFeedback] = useState<string | null>(null);
   const headers = useGenerateAuthHeaders();
+
+  Object.entries(parameters).forEach(([key, value]) => {
+    if (Array.isArray(value)) return;
+    setParams(p => ({ ...p, [key]: value.value }));
+  });
 
   useEffect(() => {
     setSubmitFeedback(null);
@@ -75,8 +81,8 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
     listWorkspaces();
   }, [onTerra, dev, rawlsApiUrl, headers]);
 
-  const handleSubmitParameters = (event: React.FormEvent<HTMLFormElement> | FormData) =>
-    submitStudyParameters(event, apiBaseUrl, studyId, headers, setSubmitFeedback);
+  const handleSubmitParameters = async (event: React.FormEvent<HTMLFormElement> | FormData) =>
+    submitStudyParameters(event, apiBaseUrl, studyId, headers, setSubmitFeedback, undefined, setParams);
 
   const filteredOptions = workspaces.filter(ws =>
     `${ws.namespace}/${ws.name}`.toLowerCase().includes(workspaceSearchTerm.toLowerCase())
@@ -200,9 +206,11 @@ const InstructionSteps: React.FC<InstructionStepsProps> = ({ demo, studyId, stud
           "sfkit.study_id": "this.study_id",
           "sfkit.data": "this.data",
           "sfkit.api_url": `\"${apiBaseUrl}/api\"`,
+          "sfkit.num_cores": params.NUM_CPUS,
+          "sfkit.boot_disk_size_gb": params.BOOT_DISK_SIZE,
         },
         outputs: {},
-        methodConfigVersion: 1,
+        methodConfigVersion: 2,
         methodRepoMethod: {
           methodUri: "dockstore://github.com%2Fhcholab%2Fsfkit/main",
         },

--- a/src/pages/studies/Study.tsx
+++ b/src/pages/studies/Study.tsx
@@ -39,7 +39,7 @@ export type DryRunFunc = (opts?: {dryRun?: boolean}) => Promise<void>;
 const Study: React.FC = () => {
   const { onTerra, apiBaseUrl, samApiUrl } = useTerra();
   const navigate = useNavigate();
-  const { study_id, auth_key = "" } = useParams();
+  const { study_id = "", auth_key = "" } = useParams();
   const headers = useGenerateAuthHeaders();
 
   const firestoreData = useFirestore();
@@ -74,8 +74,10 @@ const Study: React.FC = () => {
 
   const handleStartWorkflow: DryRunFunc = async ({ dryRun } = {}) => {
     try {
-      const url = `${apiBaseUrl}/api/start_protocol?study_id=${study_id}${dryRun ? "&dry_run" : ""}`;
-      const response = await fetch(url, {
+      const response = await fetch(`${apiBaseUrl}/api/start_protocol?${new URLSearchParams({
+        study_id,
+        ...(dryRun && { dry_run: 'true' })
+      })}`, {
         method: "POST",
         headers,
       });

--- a/src/pages/studies/Study.tsx
+++ b/src/pages/studies/Study.tsx
@@ -93,6 +93,7 @@ const Study: React.FC = () => {
       console.log("Workflow started:", data);
     } catch (error) {
       console.error("Failed to start workflow:", error);
+      throw error;
     }
   };
 

--- a/src/pages/studies/Study.tsx
+++ b/src/pages/studies/Study.tsx
@@ -57,7 +57,7 @@ const Study: React.FC = () => {
   const [showManhattanDiv, setShowManhattanDiv] = useState<boolean>(false);
   const [imageSrc, setImageSrc] = useState<string>("");
   const [imageLabel, setImageLabel] = useState<string>("");
-  const [showFailStatus, setShowFailStatus] = useState<boolean>(false);
+  const [failStatus, setFailStatus] = useState<string>("");
   const [isRestarting, setIsRestarting] = useState<boolean>(false);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
@@ -84,8 +84,7 @@ const Study: React.FC = () => {
 
       if (!response.ok) {
         const data = await response.json();
-        setErrorMessage(data.error || "Network response was not ok");
-        setShowFailStatus(true);
+        setFailStatus(data.error || "Network response was not ok");
         throw new Error("Network response was not ok");
       }
 
@@ -251,7 +250,7 @@ const Study: React.FC = () => {
                     showManhattanDiv={showManhattanDiv}
                     imageSrc={imageSrc}
                     imageLabel={imageLabel}
-                    showFailStatus={showFailStatus}
+                    failStatus={failStatus}
                     handleStartWorkflow={handleStartWorkflow}
                     handleDownloadAuthKey={onTerra ? handleDownloadSAKey : handleDownloadAuthKey}
                   />

--- a/src/pages/studies/Study.tsx
+++ b/src/pages/studies/Study.tsx
@@ -34,6 +34,8 @@ const fetchStudy = async (apiBaseUrl: string, study_id: string, headers: Record<
   }
 };
 
+export type DryRunFunc = (opts?: {dryRun?: boolean}) => Promise<void>;
+
 const Study: React.FC = () => {
   const { onTerra, apiBaseUrl, samApiUrl } = useTerra();
   const navigate = useNavigate();
@@ -70,9 +72,10 @@ const Study: React.FC = () => {
     setIsRestarting(false);
   };
 
-  const handleStartWorkflow = async () => {
+  const handleStartWorkflow: DryRunFunc = async ({ dryRun } = {}) => {
     try {
-      const response = await fetch(`${apiBaseUrl}/api/start_protocol?study_id=${study_id}`, {
+      const url = `${apiBaseUrl}/api/start_protocol?study_id=${study_id}${dryRun ? "&dry_run" : ""}`;
+      const response = await fetch(url, {
         method: "POST",
         headers,
       });

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -1,5 +1,5 @@
 export const submitStudyParameters = async (
-  formEvent: React.FormEvent<HTMLFormElement> | FormData,
+  event: React.FormEvent<HTMLFormElement>,
   apiBaseUrl: string,
   studyId: string,
   headers: HeadersInit,
@@ -7,11 +7,9 @@ export const submitStudyParameters = async (
   setErrorMessage?: (message: string) => void,
   setParams?: (params: Record<string, string | number>) => void,
 ) => {
-  if (!(formEvent instanceof FormData)) {
-    formEvent.preventDefault();
-  }
-  const formData = formEvent instanceof FormData
-    ? formEvent : new FormData(formEvent.currentTarget);
+  event.preventDefault();
+
+  const formData = new FormData(event.currentTarget);
   const parameters: Record<string, string | number> = {};
   formData.forEach((value, key) => {
     if (key === "BASE_P") {

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -4,13 +4,14 @@ export const submitStudyParameters = async (
   studyId: string,
   headers: HeadersInit,
   setFeedback?: (feedback: string) => void,
-  setErrorMessage?: (message: string) => void
+  setErrorMessage?: (message: string) => void,
+  setParams?: (params: Record<string, string | number>) => void,
 ) => {
   if (!(formEvent instanceof FormData)) {
     formEvent.preventDefault();
   }
   const formData = formEvent instanceof FormData ? formEvent : new FormData(formEvent.currentTarget);
-  const parameters: { [key: string]: string | number } = {};
+  const parameters: Record<string, string | number> = {};
   formData.forEach((value, key) => {
     if (key === "BASE_P") {
       parameters[key] = value.toString();
@@ -34,6 +35,10 @@ export const submitStudyParameters = async (
       setFeedback("Success!");
     } else {
       window.location.reload();
+    }
+
+    if (setParams) {
+      setParams(parameters);
     }
   } catch (error) {
     console.error("Failed to save study parameters:", error);

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -10,7 +10,8 @@ export const submitStudyParameters = async (
   if (!(formEvent instanceof FormData)) {
     formEvent.preventDefault();
   }
-  const formData = formEvent instanceof FormData ? formEvent : new FormData(formEvent.currentTarget);
+  const formData = formEvent instanceof FormData
+    ? formEvent : new FormData(formEvent.currentTarget);
   const parameters: Record<string, string | number> = {};
   formData.forEach((value, key) => {
     if (key === "BASE_P") {

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -1,14 +1,15 @@
 export const submitStudyParameters = async (
-  event: React.FormEvent<HTMLFormElement>,
+  formEvent: React.FormEvent<HTMLFormElement> | FormData,
   apiBaseUrl: string,
   studyId: string,
   headers: HeadersInit,
   setFeedback?: (feedback: string) => void,
   setErrorMessage?: (message: string) => void
 ) => {
-  event.preventDefault();
-
-  const formData = new FormData(event.currentTarget);
+  if (!(formEvent instanceof FormData)) {
+    formEvent.preventDefault();
+  }
+  const formData = formEvent instanceof FormData ? formEvent : new FormData(formEvent.currentTarget);
   const parameters: { [key: string]: string | number } = {};
   formData.forEach((value, key) => {
     if (key === "BASE_P") {

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -31,14 +31,14 @@ export const submitStudyParameters = async (
       throw new Error((await response.json()).error || "Unexpected error");
     }
 
+    if (setParams) {
+      setParams(parameters);
+    }
+
     if (setFeedback) {
       setFeedback("Success!");
     } else {
       window.location.reload();
-    }
-
-    if (setParams) {
-      setParams(parameters);
     }
   } catch (error) {
     console.error("Failed to save study parameters:", error);

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -1,5 +1,5 @@
 export const submitStudyParameters = async (
-  event: React.FormEvent<HTMLFormElement>,
+  eventForm: React.FormEvent<HTMLFormElement> | FormData,
   apiBaseUrl: string,
   studyId: string,
   headers: HeadersInit,
@@ -7,9 +7,11 @@ export const submitStudyParameters = async (
   setErrorMessage?: (message: string) => void,
   setParams?: (params: Record<string, string | number>) => void,
 ) => {
-  event.preventDefault();
-
-  const formData = new FormData(event.currentTarget);
+  if (!(eventForm instanceof FormData)) {
+    eventForm.preventDefault();
+  }
+  const formData = eventForm instanceof FormData
+    ? eventForm : new FormData(eventForm.currentTarget);
   const parameters: Record<string, string | number> = {};
   formData.forEach((value, key) => {
     if (key === "BASE_P") {


### PR DESCRIPTION
This PR restores pre-Terra behavior, when `/api/start_protocol` was called upon a user click on the Begin Protocol button. This ensures that all parameters are validated and are consistent when starting a protocol.

This requires adding the new `dry_run` query param when protocol is run by a user in manual mode on their machine. This way, they can validate the protocol in manual mode without actually changing protocol status or creating a VM on the backend. We also have to explicitly set `CREATE_VM` param to `Yes` when starting a protocol in non-Terra deployments, because it's now `No` by default.  And we add a button for manual validation.

Next, we also show a proper alert upon starting a protocol, either with or without `dry_run`.

Additionally, we restore "Confirm Post-Processing Configuration" button, to update the corresponding part of personal parameters as well, in case a user decides to change it.

Finally, we pass `NUM_CPUS` and `BOOT_DISK_SIZE` to the corresponding inputs in WDL workflow. For that, we also had to adjust Rawls method config submission request, and to throw all fatal errors from Rawls requests.

https://broadworkbench.atlassian.net/browse/SMC-28


